### PR TITLE
Add support for host objects in older environments

### DIFF
--- a/src/array.js
+++ b/src/array.js
@@ -2,7 +2,7 @@
  * @module Array
  */
 
-import { each as _each } from './util';
+import { each as _each, toArray } from './util';
 import { $, matches } from './selector';
 
 var ArrayProto = Array.prototype;
@@ -121,8 +121,7 @@ var push = ArrayProto.push;
  */
 
 function reverse() {
-    var elements = ArrayProto.slice.call(this);
-    return $(ArrayProto.reverse.call(elements));
+    return $(toArray(this).reverse());
 }
 
 /**

--- a/src/util.js
+++ b/src/util.js
@@ -7,8 +7,7 @@
  * @private
  */
 
-var global = new Function("return this")(),
-    slice = Array.prototype.slice;
+var global = new Function("return this")();
 
 /**
  * Convert `NodeList` to `Array`.
@@ -18,7 +17,14 @@ var global = new Function("return this")(),
  * @private
  */
 
-var toArray = (collection) => slice.call(collection);
+function toArray(collection) {
+    var length = collection.length;
+    var result = Array(length);
+    for (var i = 0; i < length; i++) {
+        result[i] = collection[i];
+    }
+    return result;
+}
 
 /**
  * Return something that can be iterated over (e.g. using `forEach`).


### PR DESCRIPTION
So I don't have to shim `Array.prototype.slice` svp
