### PR TITLE
Fix .off() for multiple elements

### DIFF
--- a/src/event/index.js
+++ b/src/event/index.js
@@ -177,7 +177,7 @@ function clearHandlers(element) {
     let key = element[eventKeyProp];
     if (handlers[key]) {
         handlers[key] = null;
-        element[key] = null;
+        element[eventKeyProp] = null;
         unusedKeys.push(key);
     }
 }


### PR DESCRIPTION
I'm having some trouble with `$el.off()` - that is to say it is not detaching event listeners from multiple elements.

When `$elements.on(type, handler)` is called, each element in `$elements` gets assigned a [`__domtastic_event__`](https://github.com/webpro/DOMtastic/blob/master/src/event/index.js#L163) attribute, which maps to an event handler in domtastic's internal [`handlers`](https://github.com/webpro/DOMtastic/blob/master/src/event/index.js#L158) array.

However, when `$elements.off(type, handler)` is called with the same type and handler, this `__domtastic_event__` is not unset - in fact its value is used as a key on the element, against which `null` is set. That is to say, if `element.__domtastic_event__` was set to `2`, then after [`clearHandlers`](https://github.com/webpro/DOMtastic/blob/master/src/event/index.js#L176-L183) was run, `element.__domtastic_event__` should have been cleared, but is still set to `2`, and instead `element['2']` is set to `null`.