### PR TITLE
allow $.html() to use number as value

### DIFF
--- a/src/dom/html.js
+++ b/src/dom/html.js
@@ -17,7 +17,7 @@ import { each } from '../util';
 
 export const html = function(fragment) {
 
-  if(typeof fragment !== 'string') {
+  if(['string', 'number'].indexOf(typeof fragment) >= 0) {
     const element = this.nodeType ? this : this[0];
     return element ? element.innerHTML : undefined;
   }

--- a/src/dom/html.js
+++ b/src/dom/html.js
@@ -17,7 +17,7 @@ import { each } from '../util';
 
 export const html = function(fragment) {
 
-  if(['string', 'number'].indexOf(typeof fragment) >= 0) {
+  if(['string', 'number'].indexOf(typeof fragment) < 0) {
     const element = this.nodeType ? this : this[0];
     return element ? element.innerHTML : undefined;
   }

--- a/src/dom/html.js
+++ b/src/dom/html.js
@@ -17,7 +17,7 @@ import { each } from '../util';
 
 export const html = function(fragment) {
 
-  if(['string', 'number'].indexOf(typeof fragment) < 0) {
+  if(fragment === undefined) {
     const element = this.nodeType ? this : this[0];
     return element ? element.innerHTML : undefined;
   }

--- a/test/spec/html.js
+++ b/test/spec/html.js
@@ -36,6 +36,11 @@ describe('html', function() {
       assert.deepEqual(actual, element);
     });
 
+    it('should set html if content is number', function () {
+      emptyContainer.html(20);
+      assert(emptyContainer[0].innerHTML === '20');
+    })
+
   });
 
   describe('set (magic)', function() {


### PR DESCRIPTION
Hi,
Doing things like ``$('.el').html(20);`` was not working because html expects value to be a string. This PR allows html to use numbers.

PS: I could not run test suits due to rollup issue with import syntax in vendors