### PR TITLE
$.val() will return undefined if collection is empty

### DIFF
--- a/src/dom/extra.js
+++ b/src/dom/extra.js
@@ -93,7 +93,7 @@ export const text = function(value) {
 export const val = function(value) {
 
   if(value === undefined) {
-    return this[0] ? this[0].value : undefined;
+    return this.length > 0 ? this[0].value : undefined;
   }
 
   return each(this, element => element.value = value);

--- a/src/dom/extra.js
+++ b/src/dom/extra.js
@@ -93,7 +93,7 @@ export const text = function(value) {
 export const val = function(value) {
 
   if(value === undefined) {
-    return this[0].value;
+    return this[0] ? this[0].value : undefined;
   }
 
   return each(this, element => element.value = value);

--- a/test/spec/dom_extra.js
+++ b/test/spec/dom_extra.js
@@ -162,6 +162,11 @@ describe('dom (extra)', function() {
       assert(element.val('smt') === element);
     });
 
+    it('should return undefined if collection is empty', function() {
+      var element = $('foo#bar');
+      assert(element.val() === undefined);
+    });
+
   });
 
 });


### PR DESCRIPTION
Calling $.val() on empty collection currently throws an exception. This PR fix that and $.val will return undefined instead