### PR TITLE
Add setting CSS property with important priority

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -51,10 +51,8 @@ export const css = function(key, value) {
   each(this, element => {
     for(prop in styleProps) {
       if(styleProps[prop] || styleProps[prop] === 0) {
-        const important = /!important$/.test(styleProps[prop]) ? 'important' : undefined;
-        if(typeof styleProps[prop] === 'string') {
-          styleProps[prop] = styleProps[prop].replace(/\s*!important$/, '');
-        }
+        const important = /!important$/.test(styleProps[prop]) ? 'important' : '';
+        styleProps[prop] = important ? styleProps[prop].replace(/\s*!important$/, '') : styleProps[prop];
         element.style.setProperty(prop, styleProps[prop], important);
       } else {
         element.style.removeProperty(prop);

--- a/src/css.js
+++ b/src/css.js
@@ -6,8 +6,6 @@ import { each } from './util';
 
 const isNumeric = value => !isNaN(parseFloat(value)) && isFinite(value);
 
-const camelize = value => value.replace(/-([\da-z])/gi, (matches, letter) => letter.toUpperCase());
-
 const dasherize = value => value.replace(/([a-z\d])([A-Z])/g, '$1-$2').toLowerCase();
 
 /**
@@ -28,12 +26,12 @@ export const css = function(key, value) {
   let styleProps, prop, val;
 
   if(typeof key === 'string') {
-    key = camelize(key);
+    key = dasherize(key);
 
     if(typeof value === 'undefined') {
       let element = this.nodeType ? this : this[0];
       if(element) {
-        val = element.style[key];
+        val = element.style.getPropertyValue(key);
         return isNumeric(val) ? parseFloat(val) : val;
       }
       return undefined;
@@ -46,16 +44,21 @@ export const css = function(key, value) {
     for(prop in styleProps) {
       val = styleProps[prop];
       delete styleProps[prop];
-      styleProps[camelize(prop)] = val;
+      styleProps[dasherize(prop)] = val;
     }
   }
 
   each(this, element => {
     for(prop in styleProps) {
+      let important = undefined;
+      if(typeof styleProps[prop] === 'string' && styleProps[prop].match(/!important$/)) {
+        styleProps[prop] = styleProps[prop].replace(/\s*!important$/, '');
+        important = 'important';
+      }
       if(styleProps[prop] || styleProps[prop] === 0) {
-        element.style[prop] = styleProps[prop];
+        element.style.setProperty(prop, styleProps[prop], important);
       } else {
-        element.style.removeProperty(dasherize(prop));
+        element.style.removeProperty(prop);
       }
     }
   });

--- a/src/css.js
+++ b/src/css.js
@@ -50,12 +50,11 @@ export const css = function(key, value) {
 
   each(this, element => {
     for(prop in styleProps) {
-      let important = undefined;
-      if(typeof styleProps[prop] === 'string' && styleProps[prop].match(/!important$/)) {
-        styleProps[prop] = styleProps[prop].replace(/\s*!important$/, '');
-        important = 'important';
-      }
       if(styleProps[prop] || styleProps[prop] === 0) {
+        const important = /!important$/.test(styleProps[prop]) ? 'important' : undefined;
+        if(typeof styleProps[prop] === 'string') {
+          styleProps[prop] = styleProps[prop].replace(/\s*!important$/, '');
+        }
         element.style.setProperty(prop, styleProps[prop], important);
       } else {
         element.style.removeProperty(prop);

--- a/test/spec/css.js
+++ b/test/spec/css.js
@@ -57,6 +57,7 @@ describe('css', function() {
       var element = $('#testFragment')[0];
       var actualValue = element.style.getPropertyValue('padding-right');
       var actualPriority = element.style.getPropertyPriority('padding-right');
+      console.log('actual/expected', actualValue, expected);
       assert(actualValue === expected);
       assert(actualPriority === 'important');
     });

--- a/test/spec/css.js
+++ b/test/spec/css.js
@@ -51,6 +51,47 @@ describe('css', function() {
       assert.doesNotThrow(fn, TypeError);
     });
 
+    it('should set style property with important priority on elements', function() {
+      var expected = '15px';
+      $('#testFragment').css('paddingRight', expected + ' !important');
+      var element = $('#testFragment')[0];
+      var actualValue = element.style.getPropertyValue('padding-right');
+      var actualPriority = element.style.getPropertyPriority('padding-right');
+      assert(actualValue === expected);
+      assert(actualPriority === 'important');
+    });
+
+    it('should set style property without important priority on elements', function() {
+      var expected = '20px';
+      $('#testFragment').css('paddingRight', '20px');
+      var element = $('#testFragment')[0];
+      var actualValue = element.style.getPropertyValue('padding-right');
+      var actualPriority = element.style.getPropertyPriority('padding-right');
+      assert(actualValue === expected);
+      assert(actualPriority === '');
+    });
+
+    it('should set multiple style property with important priority on elements', function() {
+      var element = $('#testFragment');
+      var expected = ['400', 'normal'];
+      element.css({
+        'font-weight': expected[0] + ' !important',
+        'font-style': expected[1]
+      });
+      var actualValue = [
+        element[0].style.getPropertyValue('font-weight'),
+        element[0].style.getPropertyValue('font-style')
+      ];
+      var actualPriority = [
+        element[0].style.getPropertyPriority('font-weight'),
+        element[0].style.getPropertyPriority('font-style')
+      ];
+      assert(actualValue[0] === expected[0]);
+      assert(actualPriority[0] === 'important');
+      assert(actualValue[1] === expected[1]);
+      assert(actualPriority[1] === '');
+    });
+
   });
 
   describe('get', function() {

--- a/test/spec/css.js
+++ b/test/spec/css.js
@@ -53,21 +53,20 @@ describe('css', function() {
 
     it('should set style property with important priority on elements', function() {
       var expected = '15px';
-      $('#testFragment').css('paddingRight', expected + ' !important');
-      var element = $('#testFragment')[0];
-      var actualValue = element.style.getPropertyValue('padding-right');
-      var actualPriority = element.style.getPropertyPriority('padding-right');
-      console.log('actual/expected', actualValue, expected);
+      var element = $('#testFragment');
+      element.css('paddingRight', expected + ' !important');
+      var actualValue = element[0].style.getPropertyValue('padding-right');
+      var actualPriority = element[0].style.getPropertyPriority('padding-right');
       assert(actualValue === expected);
       assert(actualPriority === 'important');
     });
 
     it('should set style property without important priority on elements', function() {
       var expected = '20px';
-      $('#testFragment').css('paddingRight', '20px');
-      var element = $('#testFragment')[0];
-      var actualValue = element.style.getPropertyValue('padding-right');
-      var actualPriority = element.style.getPropertyPriority('padding-right');
+      var element = $('#testFragment');
+      element.css('paddingRight', '20px');
+      var actualValue = element[0].style.getPropertyValue('padding-right');
+      var actualPriority = element[0].style.getPropertyPriority('padding-right');
       assert(actualValue === expected);
       assert(actualPriority === '');
     });
@@ -79,18 +78,10 @@ describe('css', function() {
         'font-weight': expected[0] + ' !important',
         'font-style': expected[1]
       });
-      var actualValue = [
-        element[0].style.getPropertyValue('font-weight'),
-        element[0].style.getPropertyValue('font-style')
-      ];
-      var actualPriority = [
-        element[0].style.getPropertyPriority('font-weight'),
-        element[0].style.getPropertyPriority('font-style')
-      ];
-      assert(actualValue[0] === expected[0]);
-      assert(actualPriority[0] === 'important');
-      assert(actualValue[1] === expected[1]);
-      assert(actualPriority[1] === '');
+      assert(element[0].style.getPropertyValue('font-weight') === expected[0]);
+      assert(element[0].style.getPropertyPriority('font-weight') === 'important');
+      assert(element[0].style.getPropertyValue('font-style') === expected[1]);
+      assert(element[0].style.getPropertyPriority('font-style') === '');
     });
 
   });


### PR DESCRIPTION
Hello, I added the ability to set properties with an important priority. No we can use it as follows:

```js
$('#testFragment').css('paddingRight', '10px !important');
```

In the tests, I did not use `getComputedStyle` because of an error in jsdom, for which inline styles are always in priority, see: https://github.com/jsdom/jsdom/issues/2485

#169 